### PR TITLE
Scheduled tasks don't run on Sunday

### DIFF
--- a/src/schejulure/core.clj
+++ b/src/schejulure/core.clj
@@ -13,7 +13,7 @@
    (hour time)
    (day time)
    (month time)
-   (day-of-week time)])
+   (-> time day-of-week dec)])
 
 (defn has? [coll item] (some #{item} coll))
 (defn all? [coll] (every? identity coll))

--- a/src/schejulure/core.clj
+++ b/src/schejulure/core.clj
@@ -13,7 +13,7 @@
    (hour time)
    (day time)
    (month time)
-   (-> time day-of-week dec)])
+   (-> time day-of-week (mod 7))])
 
 (defn has? [coll item] (some #{item} coll))
 (defn all? [coll] (every? identity coll))

--- a/test/schejulure/core_test.clj
+++ b/test/schejulure/core_test.clj
@@ -9,7 +9,8 @@
 (facts "cron-of basically works"
       (cron-of (date-time 1986 10 23 16 30)) => [30 16 23 10 4]
       (cron-of (date-time 1986 10 22 8 30)) => [30 8 22 10 3]
-      (cron-of (date-time 2000 1 1 0 0)) => [0 0 1 1 6])
+      (cron-of (date-time 2000 1 1 0 0)) => [0 0 1 1 6]
+      (cron-of (date-time 2000 1 2 0 0)) => [0 0 2 1 0])
 
 (facts "cron-match can match crons"
        (cron-match? [0 0 2 3 4] [[0 1 2] [0 1 2] [0 1 2] [0 1 2] [0 1 2]]) => false


### PR DESCRIPTION
clj-time.core/day-of-week ranges from 1-7, but schejulure expects it to range from 0-6.

This pull request changes Sundays to 0.
