### PR TITLE
Bumped clj-time to latest version and changed to using in-seconds rather...

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [clj-time "0.5.0"]]
+                 [clj-time "0.6.0"]]
   :profiles {:dev {:dependencies [[midje "1.5.1"]]
                    :plugins [[lein-midje "3.0.1"]]}})

--- a/src/schejulure/core.clj
+++ b/src/schejulure/core.clj
@@ -1,6 +1,6 @@
 (ns schejulure.core
   (:require [clj-time.core :refer [date-time year minute hour day month day-of-week
-                                   minutes in-secs interval plus now]]
+                                   minutes in-seconds interval plus now]]
             [clj-time.local :refer [local-now]])
   (:import [java.util.concurrent Executors TimeUnit]))
 
@@ -21,7 +21,7 @@
   "Given a time, will give the number of additional seconds required to
    move into the next minute"
   [time]
-  (inc (in-secs (interval time (next-minute time)))))
+  (inc (in-seconds (interval time (next-minute time)))))
 
 (defn call-every-minute
   "Schedules a function to be called every minute, within a second of


### PR DESCRIPTION
... than in-secs to get rid of annoying deprecation warning
